### PR TITLE
Added stub register method to RouteServiceProvider

### DIFF
--- a/src/Providers/RouteServiceProvider.php
+++ b/src/Providers/RouteServiceProvider.php
@@ -42,6 +42,6 @@ class RouteServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        // 
+        //
     }
 }

--- a/src/Providers/RouteServiceProvider.php
+++ b/src/Providers/RouteServiceProvider.php
@@ -36,4 +36,12 @@ class RouteServiceProvider extends ServiceProvider
             });
         }
     }
+
+    /**
+     * Stub required to satisfy Laravel 5.1's ServiceProvider
+     */
+    public function register()
+    {
+        // 
+    }
 }


### PR DESCRIPTION
laravel-fb-messenger requires version 5.1 of illuminate support, but that version's ServiceProvider declares the register method as abstract. 

I've just added a stub to your implementation to satisfy that requirement.