### PR TITLE
Relax guzzle requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "illuminate/routing": "~5.1",
         "illuminate/console": "~5.1",
         "php": ">=5.6.4",
-        "guzzlehttp/guzzle": ">=6.0 <6.3"
+        "guzzlehttp/guzzle": "^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.0",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "illuminate/routing": "~5.1",
         "illuminate/console": "~5.1",
         "php": ">=5.6.4",
-        "guzzlehttp/guzzle": "^6.2"
+        "guzzlehttp/guzzle": ">=6.0 <6.3"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.0",


### PR DESCRIPTION
I've made a change to relax the guzzle version requirement because a project I'm including this package in cannot use guzzle 6.2 due to other dependencies. 

Functionally, Guzzle 6.0 and 6.2 are very similar and this library doesn't make heavy use of Guzzle's features - so I've relaxed the requirement to allow for versions I know to work fine. It's possible the requirement could be relaxed further, but I haven't tested versions older than 6.0.