### PR TITLE
Add compatibility to newer Versions of Laravel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
         }
     ],
     "require": {
-        "illuminate/support": "~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0",
-        "illuminate/routing": "~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0",
-        "illuminate/console": "~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0",
-        "illuminate/view": "~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0",
-        "illuminate/broadcasting": "~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0",
-        "illuminate/queue": "~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0",
+        "illuminate/support": ">=5.4.0",
+        "illuminate/routing": ">=5.4.0",
+        "illuminate/console": ">=5.4.0",
+        "illuminate/view": ">=5.4.0",
+        "illuminate/broadcasting": ">=5.4.0",
+        "illuminate/queue": ">=5.4.0",
         "php": ">=5.6.4",
-        "guzzlehttp/guzzle": "^6.0"
+        "guzzlehttp/guzzle": "^6.0|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.0",


### PR DESCRIPTION
Allow to install with Laravel 6+ and to use Guzzle 7