### PR TITLE
use Arr and Str helper classes

### DIFF
--- a/src/Commands/DomainWhitelistingCommand.php
+++ b/src/Commands/DomainWhitelistingCommand.php
@@ -9,6 +9,7 @@
 namespace Casperlaitw\LaravelFbMessenger\Commands;
 
 use Casperlaitw\LaravelFbMessenger\Messages\DomainWhitelisting;
+use Illuminate\Support\Arr;
 
 /**
  * Class DomainWhitelistingCommand
@@ -51,7 +52,7 @@ class DomainWhitelistingCommand extends BaseCommand
     {
         $command = new DomainWhitelisting();
         $command->setAction(DomainWhitelisting::TYPE_READ)->useGet();
-        $response = collect(array_get($this->handler->send($command)->getResponse(), 'data.0.whitelisted_domains', []))
+        $response = collect(Arr::get($this->handler->send($command)->getResponse(), 'data.0.whitelisted_domains', []))
             ->map(function ($item) {
                 return [$item];
             });

--- a/src/Commands/HomeUrlCommand.php
+++ b/src/Commands/HomeUrlCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Casperlaitw\LaravelFbMessenger\Commands;
 
 use Casperlaitw\LaravelFbMessenger\Messages\HomeUrl;
+use Illuminate\Support\Arr;
 
 /**
  * Class HomeUrlCommand
@@ -49,7 +50,7 @@ class HomeUrlCommand extends BaseCommand
     {
         $command = new HomeUrl();
         $command->setAction(HomeUrl::TYPE_READ)->useGet();
-        $response = collect(array_get($this->handler->send($command)->getResponse(), 'data.0.home_url', []))
+        $response = collect(Arr::get($this->handler->send($command)->getResponse(), 'data.0.home_url', []))
             ->map(function ($item) {
                 return [$item];
             });

--- a/src/Commands/MessengerCodeCommand.php
+++ b/src/Commands/MessengerCodeCommand.php
@@ -3,6 +3,7 @@
 namespace Casperlaitw\LaravelFbMessenger\Commands;
 
 use Casperlaitw\LaravelFbMessenger\Messages\MessengerCode;
+use Illuminate\Support\Arr;
 
 class MessengerCodeCommand extends BaseCommand
 {
@@ -35,6 +36,6 @@ class MessengerCodeCommand extends BaseCommand
             $message->setRef($ref);
         }
 
-        $this->comment(array_get($this->handler->send($message), 'uri'));
+        $this->comment(Arr::get($this->handler->send($message), 'uri'));
     }
 }

--- a/src/Contracts/Debug/Handler.php
+++ b/src/Contracts/Debug/Handler.php
@@ -10,6 +10,7 @@ namespace Casperlaitw\LaravelFbMessenger\Contracts\Debug;
 
 use Exception;
 use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Support\Arr;
 
 class Handler implements ExceptionHandler
 {
@@ -61,9 +62,9 @@ class Handler implements ExceptionHandler
             'message' => $e->getMessage(),
             'trace' => collect($e->getTrace())->map(function ($item) {
                 return [
-                    'file' => array_get($item, 'file'),
-                    'line' => array_get($item, 'line'),
-                    'method' => array_get($item, 'function'),
+                    'file' => Arr::get($item, 'file'),
+                    'line' => Arr::get($item, 'line'),
+                    'method' => Arr::get($item, 'function'),
                 ];
             })->toArray(),
         ];

--- a/src/Contracts/HandleMessageResponse.php
+++ b/src/Contracts/HandleMessageResponse.php
@@ -7,6 +7,8 @@
 
 namespace Casperlaitw\LaravelFbMessenger\Contracts;
 
+use Illuminate\Support\Arr;
+
 /**
  * Class HandleMessageResponse
  * @package Casperlaitw\LaravelFbMessenger\Contracts
@@ -37,7 +39,7 @@ class HandleMessageResponse
         if (!empty($this->response['error'])) {
             return $this->handleError($this->response['error']);
         }
-        return array_get($this->response, 'result', $this->response);
+        return Arr::get($this->response, 'result', $this->response);
     }
 
     /**

--- a/tests/Collections/ButtonCollectionTest.php
+++ b/tests/Collections/ButtonCollectionTest.php
@@ -3,6 +3,7 @@ use Casperlaitw\LaravelFbMessenger\Collections\ButtonCollection;
 use Casperlaitw\LaravelFbMessenger\Exceptions\OnlyUseByItselfException;
 use Casperlaitw\LaravelFbMessenger\Exceptions\ValidatorStructureException;
 use Casperlaitw\LaravelFbMessenger\Messages\Button;
+use Illuminate\Support\Str;
 use Faker\Factory;
 use Mockery as m;
 
@@ -54,7 +55,7 @@ class ButtonCollectionTest extends TestCase
     {
         $fake = Factory::create();
         $collection = new ButtonCollection();
-        $title = str_random();
+        $title = Str::random();
         $phone = $fake->phoneNumber;
         $collection->addCallButton($title, $phone);
 
@@ -73,7 +74,7 @@ class ButtonCollectionTest extends TestCase
 
     public function test_add_account_link_button()
     {
-        $url = str_random();
+        $url = Str::random();
         $collection = new ButtonCollection();
         $collection->addAccountLinkButton($url);
         $expected = new Button(Button::TYPE_ACCOUNT_LINK, null, $url);

--- a/tests/Contracts/BotTest.php
+++ b/tests/Contracts/BotTest.php
@@ -6,6 +6,7 @@ use Casperlaitw\LaravelFbMessenger\Messages\Greeting;
 use Casperlaitw\LaravelFbMessenger\Messages\MessengerCode;
 use Casperlaitw\LaravelFbMessenger\Messages\User;
 use Illuminate\Broadcasting\BroadcastException;
+use Illuminate\Support\Str;
 use Illuminate\Events\Dispatcher;
 use Mockery as m;
 
@@ -24,7 +25,7 @@ class BotTest extends TestCase
 
     public function test_send_success()
     {
-        $message = new Greeting(['locale' => 'default', 'text' => str_random()]);
+        $message = new Greeting(['locale' => 'default', 'text' => Str::random()]);
         $this->bot->setSecret('test_app_secret');
         $this->bot->send($message);
     }

--- a/tests/Contracts/Debug/HandlerTest.php
+++ b/tests/Contracts/Debug/HandlerTest.php
@@ -4,6 +4,7 @@ use Casperlaitw\LaravelFbMessenger\Contracts\Debug\Handler;
 use Casperlaitw\LaravelFbMessenger\Contracts\Debug\Debug;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Events\Dispatcher;
+use Illuminate\Support\Arr;
 use Mockery as m;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -56,6 +57,6 @@ class HandlerTest extends TestCase
 
         $actual = $this->getPrivateProperty(Handler::class, 'debug')->getValue($this->handler);
         $this->assertEquals(500, $actual->getStatus());
-        $this->assertEquals('ERROR', array_get($actual->getResponse(), 'message'));
+        $this->assertEquals('ERROR', Arr::get($actual->getResponse(), 'message'));
     }
 }

--- a/tests/Contracts/Messages/AttachmentTest.php
+++ b/tests/Contracts/Messages/AttachmentTest.php
@@ -1,6 +1,7 @@
 <?php
 use Casperlaitw\LaravelFbMessenger\Contracts\Messages\Attachment;
 use Casperlaitw\LaravelFbMessenger\Exceptions\InvalidTypeException;
+use Illuminate\Support\Str;
 use Faker\Factory;
 use Mockery as m;
 
@@ -22,7 +23,7 @@ class AttachmentTest extends TestCase
     {
         parent::setUp();
         $this->faker = Factory::create();
-        $sender = str_random();
+        $sender = Str::random();
         $type = Attachment::TYPE_IMAGE;
         $image = $this->faker->url;
         $this->attachment = new AttachmentStub($sender, $type, ['url' => $image]);
@@ -57,7 +58,7 @@ class AttachmentTest extends TestCase
 
     public function test_set_attachment_id()
     {
-        $id = str_random();
+        $id = Str::random();
         $this->attachment->setAttachmentId($id);
 
         $this->assertEquals(['attachment_id' => $id], $this->attachment->getPayload());

--- a/tests/Contracts/Messages/StructuredTest.php
+++ b/tests/Contracts/Messages/StructuredTest.php
@@ -2,6 +2,7 @@
 
 use Casperlaitw\LaravelFbMessenger\Messages\Button;
 use Casperlaitw\LaravelFbMessenger\Messages\ButtonTemplate;
+use Illuminate\Support\Str;
 use Mockery as m;
 
 /**
@@ -13,13 +14,13 @@ class StructuredTest extends TestCase
 {
     public function test_call_method()
     {
-        $button = new ButtonTemplate(str_random(), str_random());
+        $button = new ButtonTemplate(Str::random(), Str::random());
         $this->assertTrue($button->validator($this->getMessageButtonMock()));
     }
 
     public function test_non_collection_method()
     {
-        $button = new ButtonTemplate(str_random(), str_random());
+        $button = new ButtonTemplate(Str::random(), Str::random());
         $button->getError();
     }
 

--- a/tests/Controllers/WebhookControllerTest.php
+++ b/tests/Controllers/WebhookControllerTest.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Config\Repository;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Str;
 use Mockery as m;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -20,7 +21,7 @@ class WebhookControllerTest extends TestCase
     public function test_index_token_verify_pass_response_challenge_token()
     {
         $verifyToken = 'MY_VERIFY_TOKEN';
-        $challenge = str_random();
+        $challenge = Str::random();
         $request = m::mock(Request::class)
             ->shouldReceive('get')
             ->with('hub_mode')
@@ -55,7 +56,7 @@ class WebhookControllerTest extends TestCase
             ->getMock();
         $config = m::mock(Repository::class)
             ->shouldReceive('get')
-            ->andReturn(str_random())
+            ->andReturn(Str::random())
             ->getMock();
         $debug = m::mock(Debug::class);
 

--- a/tests/Events/BroadcastTest.php
+++ b/tests/Events/BroadcastTest.php
@@ -1,5 +1,6 @@
 <?php
 use Casperlaitw\LaravelFbMessenger\Events\Broadcast;
+use Illuminate\Support\Str;
 
 /**
  * Created by PhpStorm.
@@ -20,7 +21,7 @@ class BroadcastTest extends TestCase
     {
         parent::setUp();
 
-        $this->id = $this->response = $this->code = $this->webhook = $this->request = str_random();
+        $this->id = $this->response = $this->code = $this->webhook = $this->request = Str::random();
         $this->broadcast = new Broadcast($this->id, $this->webhook, $this->request, $this->response, $this->code);
     }
 

--- a/tests/Messages/AudioTest.php
+++ b/tests/Messages/AudioTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Casperlaitw\LaravelFbMessenger\Messages\Audio;
+use Illuminate\Support\Str;
 use Faker\Factory;
 
 /**
@@ -13,7 +14,7 @@ class AudioTest extends TestCase
     public function test_to_data()
     {
         $faker = Factory::create();
-        $sender = str_random();
+        $sender = Str::random();
         $url = $faker->url;
 
         $actual = new Audio($sender, $url);

--- a/tests/Messages/ButtonTemplateTest.php
+++ b/tests/Messages/ButtonTemplateTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Casperlaitw\LaravelFbMessenger\Messages\ButtonTemplate;
+use Illuminate\Support\Str;
 use Mockery as m;
 use pimax\Messages\StructuredMessage;
 
@@ -19,7 +20,7 @@ class ButtonTemplateTest extends TestCase
 
     public function setUp()
     {
-        $this->sender = str_random();
+        $this->sender = Str::random();
         $this->text = 'abc';
         $this->case = new ButtonTemplate($this->sender, $this->text);
     }

--- a/tests/Messages/ElementTest.php
+++ b/tests/Messages/ElementTest.php
@@ -2,6 +2,7 @@
 use Casperlaitw\LaravelFbMessenger\Collections\ButtonCollection;
 use Casperlaitw\LaravelFbMessenger\Messages\Element;
 use Casperlaitw\LaravelFbMessenger\Messages\UrlButton;
+use Illuminate\Support\Str;
 
 /**
  * User: casperlai
@@ -13,13 +14,13 @@ class ElementTest extends TestCase
 {
     public function test_button()
     {
-        $element = new Element(str_random(), str_random());
+        $element = new Element(Str::random(), Str::random());
         $this->assertInstanceOf(ButtonCollection::class, $element->buttons());
     }
 
     public function test_default_action()
     {
-        $element = new Element(str_random(), str_random());
+        $element = new Element(Str::random(), Str::random());
         $element->setDefaultAction(new UrlButton('title', 'url'));
 
         $this->assertArraySubset([

--- a/tests/Messages/FileTest.php
+++ b/tests/Messages/FileTest.php
@@ -1,5 +1,6 @@
 <?php
 use Casperlaitw\LaravelFbMessenger\Messages\File;
+use Illuminate\Support\Str;
 use Faker\Factory;
 
 /**
@@ -12,7 +13,7 @@ class FileTest extends TestCase
     public function test_to_data()
     {
         $faker = Factory::create();
-        $sender = str_random();
+        $sender = Str::random();
         $url = $faker->url;
 
         $actual = new File($sender, $url);

--- a/tests/Messages/GenericTemplateTest.php
+++ b/tests/Messages/GenericTemplateTest.php
@@ -2,6 +2,7 @@
 
 use Casperlaitw\LaravelFbMessenger\Messages\Element;
 use Casperlaitw\LaravelFbMessenger\Messages\GenericTemplate;
+use Illuminate\Support\Str;
 use pimax\Messages\StructuredMessage;
 
 /**
@@ -17,7 +18,7 @@ class GenericTemplateTest extends TestCase
 
     public function setUp()
     {
-        $this->sender = str_random();
+        $this->sender = Str::random();
         $this->case = [
             new Element('title1', 'description1'),
             new Element('title2', 'description2')

--- a/tests/Messages/GreetingTest.php
+++ b/tests/Messages/GreetingTest.php
@@ -1,5 +1,6 @@
 <?php
 use Casperlaitw\LaravelFbMessenger\Messages\Greeting;
+use Illuminate\Support\Str;
 
 /**
  * User: casperlai
@@ -10,7 +11,7 @@ class GreetingTest extends TestCase
 {
     public function test_to_data()
     {
-        $greetingText = str_random();
+        $greetingText = Str::random();
         $expected = [
             'greeting' => [
                 [

--- a/tests/Messages/ImageTest.php
+++ b/tests/Messages/ImageTest.php
@@ -1,5 +1,6 @@
 <?php
 use Casperlaitw\LaravelFbMessenger\Messages\Image;
+use Illuminate\Support\Str;
 
 /**
  * User: casperlai
@@ -10,8 +11,8 @@ class ImageTest extends TestCase
 {
     public function test_to_data()
     {
-        $sender = str_random();
-        $image = str_random();
+        $sender = Str::random();
+        $image = Str::random();
         $expected = [
             'recipient' => [
                 'id' => $sender,

--- a/tests/Messages/ListTemplateTest.php
+++ b/tests/Messages/ListTemplateTest.php
@@ -3,6 +3,7 @@ use Casperlaitw\LaravelFbMessenger\Exceptions\ListElementCountException;
 use Casperlaitw\LaravelFbMessenger\Messages\Button;
 use Casperlaitw\LaravelFbMessenger\Messages\Element;
 use Casperlaitw\LaravelFbMessenger\Messages\ListTemplate;
+use Illuminate\Support\Str;
 
 /**
  * Created by PhpStorm.
@@ -18,7 +19,7 @@ class ListTemplateTest extends TestCase
 
     public function setUp()
     {
-        $this->sender = str_random();
+        $this->sender = Str::random();
         $this->case = [
             new Element('title1', 'description1', 'image1'),
             new Element('title2', 'description2', 'image2'),

--- a/tests/Messages/QuickReplyTest.php
+++ b/tests/Messages/QuickReplyTest.php
@@ -1,5 +1,6 @@
 <?php
 use Casperlaitw\LaravelFbMessenger\Messages\QuickReply;
+use Illuminate\Support\Str;
 
 /**
  * Created by PhpStorm.
@@ -36,7 +37,7 @@ class QuickReplyTest extends TestCase
     {
         $title = 'Red';
         $payload = 'PAYLOAD_RED';
-        $image = str_random();
+        $image = Str::random();
 
         $expected = [
             'content_type' => 'text',

--- a/tests/Messages/ReceiveMessageTest.php
+++ b/tests/Messages/ReceiveMessageTest.php
@@ -1,5 +1,6 @@
 <?php
 use Casperlaitw\LaravelFbMessenger\Messages\ReceiveMessage;
+use Illuminate\Support\Str;
 
 /**
  * User: casperlai
@@ -24,10 +25,10 @@ class ReceiveMessageTest extends TestCase
 
     public function setUp()
     {
-        $this->message = str_random();
-        $this->recipient = str_random();
-        $this->sender = str_random();
-        $this->postback = str_random();
+        $this->message = Str::random();
+        $this->recipient = Str::random();
+        $this->sender = Str::random();
+        $this->postback = Str::random();
         $this->attachments = [];
         $this->skip = true;
         $this->payload = false;

--- a/tests/Messages/StartButtonTest.php
+++ b/tests/Messages/StartButtonTest.php
@@ -1,5 +1,6 @@
 <?php
 use Casperlaitw\LaravelFbMessenger\Messages\StartButton;
+use Illuminate\Support\Str;
 
 /**
  * User: casperlai
@@ -10,7 +11,7 @@ class StartButtonTest extends TestCase
 {
     public function test_to_data()
     {
-        $payload = str_random();
+        $payload = Str::random();
         $expected = [
             'get_started' => [
                 'payload' => $payload,

--- a/tests/Messages/TextTest.php
+++ b/tests/Messages/TextTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Casperlaitw\LaravelFbMessenger\Messages\Text;
+use Illuminate\Support\Str;
 use pimax\Messages\Message;
 
 /**
@@ -12,8 +13,8 @@ class TextTest extends TestCase
 {
     public function test_to_data()
     {
-        $sender = str_random();
-        $message = str_random();
+        $sender = Str::random();
+        $message = Str::random();
         $expected = [
             'recipient' =>  [
                 'id' => $sender,

--- a/tests/Messages/UserTest.php
+++ b/tests/Messages/UserTest.php
@@ -1,5 +1,6 @@
 <?php
 use Casperlaitw\LaravelFbMessenger\Messages\User;
+use Illuminate\Support\Str;
 
 /**
  * Created by PhpStorm.
@@ -12,7 +13,7 @@ class UserTest extends TestCase
 {
     public function test_to_data()
     {
-        $sender = str_random();
+        $sender = Str::random();
         $user = new User($sender);
 
         $this->assertEquals([], $user->toData());

--- a/tests/Messages/VideoTest.php
+++ b/tests/Messages/VideoTest.php
@@ -1,5 +1,6 @@
 <?php
 use Casperlaitw\LaravelFbMessenger\Messages\Video;
+use Illuminate\Support\Str;
 use Faker\Factory;
 
 /**
@@ -12,7 +13,7 @@ class VideoTest extends TestCase
     public function test_to_data()
     {
         $faker = Factory::create();
-        $sender = str_random();
+        $sender = Str::random();
         $url = $faker->url;
 
         $actual = new Video($sender, $url);

--- a/tests/Transformers/ButtonTransformerTest.php
+++ b/tests/Transformers/ButtonTransformerTest.php
@@ -10,13 +10,14 @@ use Casperlaitw\LaravelFbMessenger\Contracts\Messages\Template;
 use Casperlaitw\LaravelFbMessenger\Exceptions\RequiredArgumentException;
 use Casperlaitw\LaravelFbMessenger\Messages\Button;
 use Casperlaitw\LaravelFbMessenger\Transformers\ButtonTransformer;
+use Illuminate\Support\Str;
 use Mockery as m;
 
 class ButtonTransformerTest extends TestCase
 {
     public function test_transform()
     {
-        $testSender = str_random();
+        $testSender = Str::random();
         $testText = 'abc';
         $testCase = [
             new Button(Button::TYPE_POSTBACK, 'test1', 'test1'),

--- a/tests/Transformers/GenericTransformerTest.php
+++ b/tests/Transformers/GenericTransformerTest.php
@@ -4,6 +4,7 @@ use Casperlaitw\LaravelFbMessenger\Collections\ElementCollection;
 use Casperlaitw\LaravelFbMessenger\Contracts\Messages\Template;
 use Casperlaitw\LaravelFbMessenger\Messages\Element;
 use Casperlaitw\LaravelFbMessenger\Transformers\GenericTransformer;
+use Illuminate\Support\Str;
 use Mockery as m;
 
 /**
@@ -15,7 +16,7 @@ class GenericTransformerTest extends TestCase
 {
     public function test_transform()
     {
-        $testSender = str_random();
+        $testSender = Str::random();
         $testCase = [
             new Element('title1', 'description2'),
             new Element('title2', 'description2', 'image_url'),

--- a/tests/Transformers/ListTransformerTest.php
+++ b/tests/Transformers/ListTransformerTest.php
@@ -5,6 +5,7 @@ use Casperlaitw\LaravelFbMessenger\Contracts\Messages\Template;
 use Casperlaitw\LaravelFbMessenger\Messages\Button;
 use Casperlaitw\LaravelFbMessenger\Messages\Element;
 use Casperlaitw\LaravelFbMessenger\Transformers\ListTransformer;
+use Illuminate\Support\Str;
 use Mockery as m;
 
 /**
@@ -18,7 +19,7 @@ class ListTransformerTest extends TestCase
 {
     public function test_transform()
     {
-        $testSender = str_random();
+        $testSender = Str::random();
         $testCase = [
             new Element('title1', 'description2', 'image_url'),
             new Element('title2', 'description2', 'image_url'),
@@ -48,13 +49,13 @@ class ListTransformerTest extends TestCase
 
     public function test_transform_without_buttons()
     {
-        $testSender = str_random();
+        $testSender = Str::random();
         $testCase = [
             new Element('title1', 'description2', 'image_url'),
             new Element('title2', 'description2', 'image_url'),
             new Element('title2', 'description2', 'image_url'),
         ];
-        
+
         $expectedCase = [];
         foreach ($testCase as $case) {
             $expectedCase[] = $case->toData();


### PR DESCRIPTION
As of [Laravel 6](https://laravel.com/docs/6.x/upgrade#helpers) all `str_` and `array_` helpers have been removed from the framework, this change update all calls to these helpers to use the Illuminate\Support\Str and Illuminate\Support\Arr classes.